### PR TITLE
Fix errors in /bin and /perl files

### DIFF
--- a/bin/GeosFpDriver.input
+++ b/bin/GeosFpDriver.input
@@ -75,6 +75,7 @@ GEOS.fp.asm.inst3_3d_asm_Nv.YYYYMMDD_hhmm.V01.nc4
 PS,PV,QV,T
 
 ==> Local Raw Data Path
+# CHANGE the year and month folder in the following line
 /storage1/fs1/rvmartin/Active/GEOS-Chem-shared/MetFieldProcessing/GEOS_FP-raw/2021/03/
 
 ==> 0.25x0.3125 Nested AF output

--- a/perl/doGeosFp.input
+++ b/perl/doGeosFp.input
@@ -29,6 +29,7 @@
 #
 
 ==> Raw Met Data Directory
+# CHANGE the year and month folder in the following line
 /storage1/fs1/rvmartin/Active/GEOS-Chem-shared/MetFieldProcessing/GEOS_FP-raw/2021/03/
 
 ==> Code Directory
@@ -41,6 +42,7 @@
 ../logs
 
 ==> Temporary Directory
+# CHANGE the year and month folder in the following line
 /storage1/fs1/rvmartin/Active/GEOS-Chem-shared/MetFieldProcessing/scratch/GEOS_FP/2021/03/
 
 ==> Program Executable

--- a/perl/moveGeosFp
+++ b/perl/moveGeosFp
@@ -245,7 +245,7 @@ sub getDirectories($) {
       $TEMP_DIR_NEST_EU  = $file[++$i];
       $DATA_DIR_NEST_EU  = $file[++$i];
 
-    if ( $file[$i] =~ "==> 0.25x0.3125 Nested ME output" ) {
+    } elsif ( $file[$i] =~ "==> 0.25x0.3125 Nested ME output" ) {
       $DO_NEST_ME        = $file[++$i];
       $DATA_FILE_NEST_ME = $file[++$i];
       $TEMP_DIR_NEST_ME  = $file[++$i];
@@ -257,19 +257,19 @@ sub getDirectories($) {
       $TEMP_DIR_NEST_NA  = $file[++$i];
       $DATA_DIR_NEST_NA  = $file[++$i];
 
-    if ( $file[$i] =~ "==> 0.25x0.3125 Nested OC output" ) {
+    } elsif ( $file[$i] =~ "==> 0.25x0.3125 Nested OC output" ) {
       $DO_NEST_OC        = $file[++$i];
       $DATA_FILE_NEST_OC = $file[++$i];
       $TEMP_DIR_NEST_OC  = $file[++$i];
       $DATA_DIR_NEST_OC  = $file[++$i];
 
-    if ( $file[$i] =~ "==> 0.25x0.3125 Nested RU output" ) {
+    } elsif ( $file[$i] =~ "==> 0.25x0.3125 Nested RU output" ) {
       $DO_NEST_RU        = $file[++$i];
       $DATA_FILE_NEST_RU = $file[++$i];
       $TEMP_DIR_NEST_RU  = $file[++$i];
       $DATA_DIR_NEST_RU  = $file[++$i];
 
-    if ( $file[$i] =~ "==> 0.25x0.3125 Nested SA output" ) {
+    } elsif ( $file[$i] =~ "==> 0.25x0.3125 Nested SA output" ) {
       $DO_NEST_SA        = $file[++$i];
       $DATA_FILE_NEST_SA = $file[++$i];
       $TEMP_DIR_NEST_SA  = $file[++$i];
@@ -293,14 +293,14 @@ sub getDirectories($) {
       $TEMP_DIR_NEST_NA_05  = $file[++$i];
       $DATA_DIR_NEST_NA_05  = $file[++$i];
 
-    if ( $file[$i] =~ "==> 0.25x0.3125 global output" ) {
+    } elsif ( $file[$i] =~ "==> 0.25x0.3125 global output" ) {
       $DO_025x03125        = $file[++$i];
       $DATA_FILE_025x03125 = $file[++$i];
       $TEMP_DIR_025x03125  = $file[++$i];
       $DATA_DIR_025x03125  = $file[++$i];
 
-    if ( $file[$i] =~ "==> 0.5x0.625 global output" ) {
-      $DO_05x06125        = $file[++$i];
+    } elsif ( $file[$i] =~ "==> 0.5x0.625 global output" ) {
+      $DO_05x0625        = $file[++$i];
       $DATA_FILE_05x0625 = $file[++$i];
       $TEMP_DIR_05x0625  = $file[++$i];
       $DATA_DIR_05x0625  = $file[++$i];


### PR DESCRIPTION
The following files have been modified:

/bin/GeosFpDriver.input
/perl/doGeosFp.input
/perl/moveGeosFp

For the first two files, since the problematic lines of code are hard-coded ones, I added a comment immediately above those lines to change the year and month.

Beyond the above issues, there could also be other files with errors in the GEOS_FP folder as I am getting stop code error messages while processing.